### PR TITLE
use 'experimental.pm' for pushing to arrayref

### DIFF
--- a/lib/Games/FrogJump/Board.pm
+++ b/lib/Games/FrogJump/Board.pm
@@ -2,6 +2,7 @@ package Games::FrogJump::Board;
 use 5.012;
 use strict;
 use warnings;
+use experimental 'autoderef';
 use Moo;
 
 use if $^O eq "MSWin32", "Win32::Console::ANSI";


### PR DESCRIPTION
On perl v5.20 you should [explicitly declare](https://metacpan.org/pod/experimental#DESCRIPTION) that you want do use autodereferencing behavior of push, pop etc. Otherwise the game dies with the following trace:

```
push on reference is experimental at /home/sromanov/perl5/perlbrew/perls/perl-5.20.0/lib/site_perl/5.20.0/Games/FrogJump/Board.pm line 136.
Compilation failed in require at /home/sromanov/perl5/perlbrew/perls/perl-5.20.0/lib/site_perl/5.20.0/Module/Runtime.pm line 317.
Compilation failed in require at /home/sromanov/perl5/perlbrew/perls/perl-5.20.0/lib/site_perl/5.20.0/Games/FrogJump.pm line 43.
BEGIN failed--compilation aborted at /home/sromanov/perl5/perlbrew/perls/perl-5.20.0/lib/site_perl/5.20.0/Games/FrogJump.pm line 43.
Compilation failed in require at /home/sromanov/perl5/perlbrew/perls/perl-5.20.0/bin/frogjump line 3.
BEGIN failed--compilation aborted at /home/sromanov/perl5/perlbrew/perls/perl-5.20.0/bin/frogjump line 3.
```

This PR fixes this fatal warning (an alternative being `Moo::Lax`).

Cheers!
